### PR TITLE
Fix the find detection

### DIFF
--- a/MicroPython/I Pico W LED web server/main.py
+++ b/MicroPython/I Pico W LED web server/main.py
@@ -97,11 +97,11 @@ while True:
         led_off = r.find('?led=off')
         print('led_on = ', led_on)
         print('led_off = ', led_off)
-        if led_on == 10:
+        if led_on > -1:
             print('LED ON')
             led.value(1)
             
-        if led_off == 10:
+        if led_off > -1:
             print('LED OFF')
             led.value(0)
             


### PR DESCRIPTION
the condition ==10 is only valid for specific length of IP address. If the URL is shorter/longer, the find will result in different number, failing the condition.
Using the -1 will fix this issue.